### PR TITLE
Update chocolatey package to use python3 NO_JIRA

### DIFF
--- a/tasks/Windows.yml
+++ b/tasks/Windows.yml
@@ -2,5 +2,5 @@
 - name: Install Python 3.x
   win_chocolatey:
     name:
-      - python
+      - python3
     state: present


### PR DESCRIPTION
Recently had failures because artifactory would not find updated python3 package from python package.

Screenshot of error:

<img width="472" alt="image" src="https://user-images.githubusercontent.com/111884/147479109-d4b6f76f-63d0-417e-8246-acd7ad99df20.png">
