### PR TITLE
Update CentOS.yml to use latet python3 NO_JIRA

### DIFF
--- a/tasks/CentOS.yml
+++ b/tasks/CentOS.yml
@@ -5,8 +5,8 @@
       # We do need python-setuptools (for the installed 2.7) on CentOS, as
       # otherwise ansible's pip module will fail to work
       - python-setuptools
-      - python36
-      - python36-pip
+      - python3
+      - python3-pip
     state: present
     use_backend: yum
   become: true


### PR DESCRIPTION
No har req for python 3.6, it's unsupported, and other OS's dont have this pinned.